### PR TITLE
add signal test

### DIFF
--- a/internal/agent/candidate.go
+++ b/internal/agent/candidate.go
@@ -73,7 +73,7 @@ func election() error {
 	}
 
 	voteCount := 0
-	r := time.Duration(rand.Intn(10)) * time.Second
+	r := time.Duration(rand.Intn(electionTimeoutRandMaxSec)) * time.Second
 	for {
 		select {
 		case <-time.After(electionTimeout + r):

--- a/internal/agent/common.go
+++ b/internal/agent/common.go
@@ -19,9 +19,11 @@ const (
 	Candidate
 	Leader
 
-	InvalidLockHolderID int32 = -1
-	InvalidAgentID      int32 = -1
-	NoopAgentID         int32 = -2
+	InvalidLockHolderID       int32 = -1
+	InvalidAgentID            int32 = -1
+	NoopAgentID               int32 = -2
+	electionTimeout                 = 2 * time.Second
+	electionTimeoutRandMaxSec       = 5
 )
 
 type StateMachine struct {

--- a/internal/agent/follower.go
+++ b/internal/agent/follower.go
@@ -9,7 +9,7 @@ import (
 func checkElectionTimeout() {
 	electionTimeoutBase = time.Now()
 	ticker := time.NewTicker(time.Microsecond * 100)
-	r := time.Duration(rand.Intn(10)) * time.Second
+	r := time.Duration(rand.Intn(electionTimeoutRandMaxSec)) * time.Second
 	for {
 		<-ticker.C
 		if time.Since(electionTimeoutBase) > electionTimeout+r {

--- a/internal/agent/rpcserver.go
+++ b/internal/agent/rpcserver.go
@@ -17,10 +17,6 @@ type RaftServerImpl struct {
 	sfrpc.UnimplementedRaftServer
 }
 
-const (
-	electionTimeout = 2 * time.Second
-)
-
 var (
 	electionTimeoutBase time.Time
 )

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -43,6 +43,7 @@ func TestLockAndUnlock(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			return false
 		}
+		defer resp.Body.Close()
 		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, strconv.Itoa(int(agent.InvalidLockHolderID)), string(data))
@@ -64,6 +65,7 @@ func TestLockAndUnlock(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			return false
 		}
+		defer resp.Body.Close()
 		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, lockHolder1, string(data))
@@ -94,6 +96,7 @@ func TestLockAndUnlock(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			return false
 		}
+		defer resp.Body.Close()
 		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, strconv.Itoa(int(agent.InvalidLockHolderID)), string(data))

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -22,14 +22,19 @@ type config struct {
 	GRPCEndpoints []string `yaml:"grpcEndpoints"`
 }
 
-// TODO: "Eventually" is needed for PUT requests, too.
-func TestLockAndUnlock(t *testing.T) {
-	configFileName := "../config.yaml"
-	data, err := os.ReadFile(configFileName)
+func readConfig(t *testing.T, fileName string) *config {
+	t.Helper()
+	data, err := os.ReadFile(fileName)
 	require.NoError(t, err)
 	c := config{}
 	err = yaml.Unmarshal(data, &c)
 	require.NoError(t, err)
+	return &c
+}
+
+// TODO: "Eventually" is needed for PUT requests, too.
+func TestLockAndUnlock(t *testing.T) {
+	c := readConfig(t, "../config.yaml")
 
 	// Check the initial status.
 	require.Eventually(t, func() bool {
@@ -38,7 +43,7 @@ func TestLockAndUnlock(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			return false
 		}
-		data, err = io.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, strconv.Itoa(int(agent.InvalidLockHolderID)), string(data))
 		return true
@@ -59,7 +64,7 @@ func TestLockAndUnlock(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			return false
 		}
-		data, err = io.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, lockHolder1, string(data))
 		return true
@@ -89,7 +94,7 @@ func TestLockAndUnlock(t *testing.T) {
 		if resp.StatusCode != http.StatusOK {
 			return false
 		}
-		data, err = io.ReadAll(resp.Body)
+		data, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		assert.Equal(t, strconv.Itoa(int(agent.InvalidLockHolderID)), string(data))
 		return true

--- a/test/leader_sigstop_test.go
+++ b/test/leader_sigstop_test.go
@@ -1,0 +1,87 @@
+package test
+
+import (
+	"bytes"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func sendSignal(t *testing.T, sig syscall.Signal, pid int) {
+	err := syscall.Kill(pid, sig)
+	require.NoError(t, err)
+}
+
+func TestLeaderSigStop(t *testing.T) {
+	c := readConfig(t, "../config.yaml")
+
+	lockHolder := strconv.Itoa(1)
+	require.Eventually(t, func() bool {
+		req, err := http.NewRequest(http.MethodPut,
+			c.WebEndpoints[rand.Intn(len(c.WebEndpoints))]+"/lock",
+			bytes.NewBuffer([]byte(lockHolder)))
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		return resp.StatusCode == http.StatusOK
+	}, 2*time.Second, 10*time.Microsecond)
+
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(c.WebEndpoints[rand.Intn(len(c.WebEndpoints))] + "/lock")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		data, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, lockHolder, string(data))
+		return true
+	}, 2*time.Second, 10*time.Microsecond)
+
+	cmd := exec.Command("pidof", "starfish")
+	var out strings.Builder
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pidsStr := strings.Split(out.String(), " ")
+	pids := make([]int, 0, len(pidsStr))
+	for _, pidStr := range pidsStr {
+		pid, err := strconv.Atoi(strings.TrimSpace(pidStr))
+		require.NoError(t, err)
+		pids = append(pids, pid)
+	}
+
+	for _, pid := range pids {
+		sendSignal(t, syscall.SIGSTOP, pid)
+		time.Sleep(10 * time.Second)
+		sendSignal(t, syscall.SIGCONT, pid)
+		for _, endpoint := range c.WebEndpoints {
+			require.Eventually(t, func() bool {
+				t.Logf("Stopped PID: %d", pid)
+				t.Logf("endpoint: %s", endpoint)
+				resp, err := http.Get(endpoint + "/lock")
+				require.NoError(t, err)
+				defer resp.Body.Close()
+				t.Logf("statusCode: %d", resp.StatusCode)
+				require.Equal(t, http.StatusOK, resp.StatusCode)
+				data, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				t.Logf("lockHolder: %s", string(data))
+				require.Equal(t, lockHolder, string(data))
+				return true
+			}, 2*time.Second, 20*time.Microsecond)
+		}
+	}
+}

--- a/test/stress_test.go
+++ b/test/stress_test.go
@@ -41,6 +41,7 @@ func TestStress(t *testing.T) {
 				if resp.StatusCode != http.StatusOK {
 					return false
 				}
+				defer resp.Body.Close()
 				data, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				assert.Equal(t, lockHolder, string(data))

--- a/test/stress_test.go
+++ b/test/stress_test.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -13,16 +12,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/yaml.v2"
 )
 
 func TestStress(t *testing.T) {
-	configFileName := "../config.yaml"
-	data, err := os.ReadFile(configFileName)
-	require.NoError(t, err)
-	c := config{}
-	err = yaml.Unmarshal(data, &c)
-	require.NoError(t, err)
+	c := readConfig(t, "../config.yaml")
 
 	wg := sync.WaitGroup{}
 	clientCount := 16
@@ -48,7 +41,7 @@ func TestStress(t *testing.T) {
 				if resp.StatusCode != http.StatusOK {
 					return false
 				}
-				data, err = io.ReadAll(resp.Body)
+				data, err := io.ReadAll(resp.Body)
 				require.NoError(t, err)
 				assert.Equal(t, lockHolder, string(data))
 				return true


### PR DESCRIPTION
- adjust the election timeout seconds
- create a common function to read a config file
- close resp.Body
- add a leader failover test by SIGSTOP and SIGCONT
